### PR TITLE
Add ability to add custom metadata to session table

### DIFF
--- a/src/app/TypeormStore/TypeormStore.ts
+++ b/src/app/TypeormStore/TypeormStore.ts
@@ -99,11 +99,11 @@ export class TypeormStore extends Store {
         .setParameters({ expiredAt: Date.now() })
         .execute()
       : Promise.resolve())
-      .then(() => this.repository.save({
+      .then(() => this.saveSession({
         expiredAt: Date.now() + ttl * 1000,
         id: sid,
         json,
-      }))
+      }, sess))
       .then(() => {
         this.debug("SET complete");
 
@@ -192,6 +192,12 @@ export class TypeormStore extends Store {
       });
   }
 
+  protected saveSession(session: ISession, sessionData: any) {
+    // ignore TS6133 'sessionData' is declared but never read
+    sessionData = sessionData;
+    return this.repository.save(session);
+  }
+
   private createQueryBuilder() {
     return this.repository.createQueryBuilder("session")
       .where("session.expiredAt > :expiredAt", { expiredAt: Date.now() });
@@ -211,4 +217,5 @@ export class TypeormStore extends Store {
     this.debug("Typeorm returned err", er);
     this.emit("disconnect", er);
   }
+
 }

--- a/src/app/TypeormStore/TypeormStore.ts
+++ b/src/app/TypeormStore/TypeormStore.ts
@@ -192,7 +192,7 @@ export class TypeormStore extends Store {
       });
   }
 
-  protected saveSession(session: ISession, sessionData: any) {
+  protected saveSession(session: ISession, sessionData: any): Promise<ISession> {
     // ignore TS6133 'sessionData' is declared but never read
     sessionData = sessionData;
     return this.repository.save(session);


### PR DESCRIPTION
Hi there,

Since there is an `ISession` interface and it is possible to add custom columns to the `Session` entity, I have extracted the `repository.save` part into a separate protected function to allow for easy overrides.

For example, if we wanted to add a `userId` column to the session table to be able to fetch all sessions for a specific user:

```typescript
class MySessionStore extends TypeormStore {
  protected saveSession(session: ISession, sessionData: any) {
    (session as any).userId = sessionData.userId;
    return super.saveSession(session, sessionData);
  }
}
```

Let me know what you think!