### PR TITLE
Update README.md - Added import of TypeormStore to make the example more explicit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Pass repository to `TypeormStore`:
 // src/app/Api/Api.ts
 
 import * as Express from "express";
+import {TypeormStore} from 'connect-typeorm/out';
 import * as ExpressSession from "express-session";
 import { Db } from "typeorm-static";
 import { Session } from "../../domain/Session/Session";


### PR DESCRIPTION
Added ```import {TypeormStore} from 'connect-typeorm/out';``` to make the example more explicit. As I experienced errors without explicitly adding this.