### PR TITLE
Clean up sessions that have been soft-deleted.

### DIFF
--- a/src/app/TypeormStore/TypeormStore.ts
+++ b/src/app/TypeormStore/TypeormStore.ts
@@ -103,6 +103,7 @@ export class TypeormStore extends Store {
       ? (() => {
           const $ = this.repository
             .createQueryBuilder("session")
+            .withDeleted()
             .select("session.id")
             .where(`session.expiredAt <= ${Date.now()}`)
             .limit(this.cleanupLimit);


### PR DESCRIPTION
The query that finds expired sessions ignores any soft deletes. This change causes both naturally expiring and explicitly removed sessions to be cleaned up.

Follows up on #25 which is a welcome addition.